### PR TITLE
enable CompanyName.udemy.com recognition

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,7 +11,7 @@
 	"permissions": ["storage"],
 	"content_scripts": [
 		{
-			"matches": ["https://www.udemy.com/*"],
+			"matches": ["https://*.udemy.com/*"],
 			"js": ["playbackRate.js"],
 			"css": ["menuList.css"]
 		}


### PR DESCRIPTION
This change allows for the extension to support not only "www.udemy.com" but also "CompanyName.udemy.com"